### PR TITLE
Fix 410 error caused by e621.net pagination validation change

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -759,7 +759,7 @@ $(function () {
             //rating = rating+"+rating:q";
         }
 
-        var jsonUrl = "https://e621.net/posts.json?tags="+e621pRating+"+"+e621pTags +"&limit="+ e621pLimit+`&page=${e621pAfterId != 0 ? (e621pDescending ? "b": "a") : ("") }`+e621pAfterId;
+        var jsonUrl = "https://e621.net/posts.json?tags="+e621pRating+"+"+e621pTags +"&limit="+ e621pLimit+(e621pAfterId != 0 ? `&page=${e621pDescending ? "b" : "a"}${e621pAfterId}` : "");
         //console.log(jsonUrl);
         //log(jsonUrl);
         var failedAjax = function (data) {


### PR DESCRIPTION
e621ng PR #2036 (May 16 2026) made page=0 return HTTP 410 instead of silently modifying it to page 1. On first load, e621pAfterId is 0 and the old URL construction appended &page=0, breaking every initial request.

Fix: only append the &page= cursor parameter when e621pAfterId != 0. First-page requests now omit the parameter entirely, which e621.net defaults to page 1.